### PR TITLE
Fix disappearing measurement rulers and labels on unit change and clicking off model

### DIFF
--- a/src/components/object-measurement-tools.tsx
+++ b/src/components/object-measurement-tools.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import useStore from '@/Store';
 import { Intersection, Object3D, Object3DEventMap, Vector3 } from 'three';


### PR DESCRIPTION
Clicking off the model or changing the measurement unit currently causes measurement rulers and labels to disappear in object measurement mode. The issue is caused by the Ref used to store points, rulers, etc., it doesn't update appropriately on change of measurement unit or when clicking off model. Screen measurement tools don't use Refs for this purpose, instead grabbing the HTML DOM elements dynamically. This PR modifies object measurements to use the same approach as screen measurements, which fixes this issue.