### PR TITLE
Fix scale issues

### DIFF
--- a/src/components/object-measurement-tools.tsx
+++ b/src/components/object-measurement-tools.tsx
@@ -140,16 +140,16 @@ export function ObjectMeasurementTools() {
 
       if (measurementUnits === 'mm') {
         worldDistance *= 1000;
-        // round to two decimal places
-        worldDistance = Math.round(worldDistance);
+        // round to three decimal places
+        worldDistance = parseFloat(worldDistance.toFixed(3));
       } else {
-        // round to two decimal places
-        worldDistance = parseFloat(worldDistance.toFixed(2));
+        // round to three decimal places
+        worldDistance = parseFloat(worldDistance.toFixed(3));
       }
 
       label.innerHTML = `
         <div>
-          ${worldDistance} ${measurementUnits}
+          ${worldDistance == 0 ? '<0.001' : worldDistance} ${measurementUnits}
         </div>
       `;
     }

--- a/src/components/screen-measurement-tools.tsx
+++ b/src/components/screen-measurement-tools.tsx
@@ -90,8 +90,7 @@ export function ScreenMeasurementTools() {
           y2={nextPosition[1]}
         >
           <div>
-            {worldDistance}
-            {measurementUnits}
+            {worldDistance == 0 ? '<0.001' : worldDistance} {measurementUnits}
           </div>
         </foreignObject>
       </>
@@ -184,7 +183,7 @@ export function ScreenMeasurementTools() {
 
       if (labels[i].firstElementChild) {
         labels[i].firstElementChild!.textContent = `
-          ${worldDistance}
+          ${worldDistance == 0 ? '<0.001' : worldDistance}
           ${measurementUnits}
         `;
       }
@@ -198,8 +197,8 @@ export function ScreenMeasurementTools() {
     let worldDistance = distance / camera.zoom;
     if (measurementUnits === 'mm') worldDistance *= 1000;
 
-    // round to two decimal places
-    worldDistance = parseFloat(worldDistance.toFixed(2));
+    // round to three decimal places
+    worldDistance = parseFloat(worldDistance.toFixed(3));
 
     return worldDistance;
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { Src, SrcObj } from '@/types';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { Vector3 } from 'three';
+import { Box3, Object3D, Sphere, Vector3 } from 'three';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -9,6 +9,12 @@ export function cn(...inputs: ClassValue[]) {
 
 export function areObjectsIdentical(a: any, b: any) {
   return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function getBoundingSphereRadius(object: Object3D) {
+  const box = new Box3().setFromObject(object);
+  const sphere = box.getBoundingSphere(new Sphere());
+  return sphere.radius;
 }
 
 export function normalizeSrc(src: Src): SrcObj[] {


### PR DESCRIPTION
Putting Aleph on MorphoSource (which is live now as of this weekend!) brought up a few issues relating to having objects at either very small or very large scales. This PR introduces fixes to some of those issues:

* Some very very small objects (less than a millimeter across) were not viewable at all due to default camera near and far planes. Near and far planes are now calculated on object load to provide a good viewing experience. Different calculations are used for perspective and orthographic cameras, due to how the camera-controls library uses dolly for perspective camera but zoom for orthographic (also to prevent orthographic from having too deep of a frustum plane and causing flickering models from z-index fighting).
* When grid is displayed, grid cell width/length is now scaled to object size as well. The scaling is such that an object one millimeter across will have a grid where each cell is one-tenth of a millimeter across, or an object that is one meter across will have a grid where each cell is one-tenth of a meter across, etc. 
* For very small objects, measurement tools could report lengths of "0 m". These have been replaced with "<0.001 m". 
* Number of decimal places for measurement label values increased from 2 to 3, which is more common in scientific applications.