### PR TITLE
Model orientation control, new lighting preset, scaled axes, and better camera configuration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,7 @@ function App() {
             srcs
               .filter((srcObj) => srcObj.requiredStatement)
               .forEach((srcObj) => {
-                const sanitizedHTML = DOMPurify.sanitize(srcObj.requiredStatement);
+                const sanitizedHTML = DOMPurify.sanitize(srcObj.requiredStatement as string);
                 toast(<div dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />);
               });
           }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ function App() {
           'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/FlightHelmet/glTF/FlightHelmet.gltf',
         'Roberto Clemente Batting Helmet':
           'https://cdn.glitch.global/2658666b-2aa1-4395-8dfe-44a4aaaa0b16/nmah-1981_0706_06-clemente_helmet-100k-2048_std_draco.glb?v=1729600102458',
+        'Stanford Bunny': 
+          'https://raw.githubusercontent.com/JulieWinchester/aleph-assets/main/bunny.glb',
         Shoe: {
           url: 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb',
           requiredStatement:

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -14,6 +14,7 @@ type State = {
   measurementUnits: 'm' | 'mm';
   mode: Mode;
   objectMeasurements: ObjectMeasurement[];
+  orientation: UpVector;
   orthographicEnabled: boolean;
   screenMeasurements: ScreenMeasurement[];
   selectedAnnotation: number | null;
@@ -30,6 +31,7 @@ type State = {
   setMeasurementUnits: (measurementUnits: 'm' | 'mm') => void;
   setMode: (mode: Mode) => void;
   setObjectMeasurements: (measurements: ObjectMeasurement[]) => void;
+  setOrientation: (orientation: UpVector) => void;
   setOrthographicEnabled: (orthographicEnabled: boolean) => void;
   setScreenMeasurements: (measurements: ScreenMeasurement[]) => void;
   setSelectedAnnotation: (selectedAnnotation: number | null) => void;
@@ -49,6 +51,7 @@ const useStore = create<State>((set) => ({
   measurementUnits: 'm',
   mode: 'scene',
   objectMeasurements: [],
+  orientation: 'y-positive',
   orthographicEnabled: false,
   screenMeasurements: [],
   selectedAnnotation: null,
@@ -118,6 +121,11 @@ const useStore = create<State>((set) => ({
   setObjectMeasurements: (measurements: ObjectMeasurement[]) =>
     set({
       objectMeasurements: measurements,
+    }),
+
+  setOrientation: (orientation: UpVector) =>
+    set({
+      orientation,
     }),
 
   setOrthographicEnabled: (orthographicEnabled: boolean) =>

--- a/src/components/annotation-tools.tsx
+++ b/src/components/annotation-tools.tsx
@@ -58,7 +58,6 @@ export function AnnotationTools({ cameraRefs }: { cameraRefs: CameraRefs }) {
     // rotate back to original state and then apply new rotation
     anno.position = anno.position?.applyEuler(invertPrevRotation).applyEuler(rotation);
     anno.normal = anno.normal?.applyEuler(invertPrevRotation).applyEuler(rotation);
-    anno.cameraPosition = anno.cameraPosition?.applyEuler(invertPrevRotation).applyEuler(rotation);
     anno.cameraTarget = anno.cameraTarget?.applyEuler(invertPrevRotation).applyEuler(rotation);
     anno.rotation = rotation;
 
@@ -242,7 +241,7 @@ export function AnnotationTools({ cameraRefs }: { cameraRefs: CameraRefs }) {
                         return {
                           ...anno,
                           position: intersects[0].point,
-                          normal: intersects[0].face?.normal!,
+                          normal: intersects[0].face?.normal!.applyEuler(anno.rotation!),
                           cameraPosition: cameraRefs.position.current!,
                           cameraTarget: cameraRefs.target.current!,
                         };
@@ -296,14 +295,16 @@ export function AnnotationTools({ cameraRefs }: { cameraRefs: CameraRefs }) {
           const intersects: Intersection<Object3D>[] = getIntersects();
 
           if (intersects.length > 0) {
+            const rotation = getEulerFromOrientation(orientation);
+
             setAnnotations([
               ...annotations,
               {
                 position: intersects[0].point,
-                normal: intersects[0].face?.normal!,
+                normal: intersects[0].face?.normal!.applyEuler(rotation),
                 cameraPosition: cameraRefs.position.current!,
                 cameraTarget: cameraRefs.target.current!,
-                rotation: getEulerFromOrientation(orientation)
+                rotation: rotation
               },
             ]);
 

--- a/src/components/display-controls.tsx
+++ b/src/components/display-controls.tsx
@@ -1,12 +1,14 @@
 import { CameraModeSelector } from './camera-mode-selector';
+import { OrientationSelector } from './orientation-selector';
 import { RecenterButton } from './recenter-button';
 import { TabSection } from "./tab-section";
-import { UpVectorSelector } from './upvector-selector';
+// import { UpVectorSelector } from './upvector-selector';
 
-export function CameraPanel() {
+export function DisplayControls() {
   return (
     <TabSection className="mt-4 pt-4">
-      <UpVectorSelector />
+      <OrientationSelector />
+      {/* <UpVectorSelector /> */}
       <CameraModeSelector />
       <RecenterButton />
     </TabSection>

--- a/src/components/gltf.tsx
+++ b/src/components/gltf.tsx
@@ -1,14 +1,17 @@
 import { useRef } from 'react';
 import { useGLTF } from '@react-three/drei';
 // import { a } from '@react-spring/three';
-import { Group } from 'three';
+import { Euler, Group } from 'three';
+import { UpVector } from '@/types';
 import { SrcObj } from '@/types/Src';
+import { getEulerAnglesFromOrientation } from '@/lib/utils';
 
 type GLTFProps = SrcObj & {
+  orientation?: UpVector;
   onLoad?: (url: string) => void;
 };
 
-export const GLTF = ({ url, position = [0, 0, 0], rotation = [0, 0, 0], scale = [1, 1, 1], onLoad }: GLTFProps) => {
+export const GLTF = ({ url, position = [0, 0, 0], rotation = [0, 0, 0], scale = [1, 1, 1], orientation, onLoad }: GLTFProps) => {
   const { scene } = useGLTF(url, true, true, (e) => {
     // @ts-ignore
     e.manager.onLoad = () => {
@@ -20,11 +23,13 @@ export const GLTF = ({ url, position = [0, 0, 0], rotation = [0, 0, 0], scale = 
   const ref = useRef<Group | null>(null);
   const modelRef = useRef();
 
+  const outerRotation = new Euler().fromArray(getEulerAnglesFromOrientation(orientation || 'y-positive'));
+  
   return (
     <>
       {/* @ts-ignore: https://github.com/pmndrs/react-spring/issues/1515 */}
-      <group ref={ref} position={position} rotation={rotation} scale={scale}>
-        <primitive ref={modelRef} object={scene} scale={scale} />
+      <group ref={ref} position={position} rotation={outerRotation} scale={scale}>
+        <primitive ref={modelRef} object={scene} rotation={rotation} scale={scale} />
       </group>
     </>
   );

--- a/src/components/import-annotations-dialog.tsx
+++ b/src/components/import-annotations-dialog.tsx
@@ -48,6 +48,11 @@ export function AnnotationsDialog() {
     { label: 'camera_target_x', key: 'cameraTarget.x' },
     { label: 'camera_target_y', key: 'cameraTarget.y' },
     { label: 'camera_target_z', key: 'cameraTarget.z' },
+    { label: 'rotation_is_euler', key: 'rotation.isEuler' },
+    { label: 'rotation_x', key: 'rotation._x' },
+    { label: 'rotation_y', key: 'rotation._y' },
+    { label: 'rotation_z', key: 'rotation._z' },
+    { label: 'rotation_order', key: 'rotation._order' },
   ];
 
   return (

--- a/src/components/object-measurement-tools.tsx
+++ b/src/components/object-measurement-tools.tsx
@@ -140,16 +140,16 @@ export function ObjectMeasurementTools() {
 
       if (measurementUnits === 'mm') {
         worldDistance *= 1000;
-        // round to two decimal places
-        worldDistance = Math.round(worldDistance);
+        // round to three decimal places
+        worldDistance = parseFloat(worldDistance.toFixed(3));
       } else {
-        // round to two decimal places
-        worldDistance = parseFloat(worldDistance.toFixed(2));
+        // round to three decimal places
+        worldDistance = parseFloat(worldDistance.toFixed(3));
       }
 
       label.innerHTML = `
         <div>
-          ${worldDistance} ${measurementUnits}
+          ${worldDistance == 0 ? '<0.001' : worldDistance} ${measurementUnits}
         </div>
       `;
     }

--- a/src/components/orientation-selector.tsx
+++ b/src/components/orientation-selector.tsx
@@ -4,24 +4,24 @@ import useStore from '@/Store';
 import { OptionSelector } from './option-selector';
 import { UpVector } from '@/types';
 
-export function UpVectorSelector() {
-  const { upVector, setUpVector } = useStore();
+export function OrientationSelector() {
+  const { orientation, setOrientation } = useStore();
  
   const handleChange = (value: string) => {
-    setUpVector(value as UpVector);
+    setOrientation(value as UpVector);
   };
 
   return (
     <OptionSelector
-      label="Camera Up"
-      description="Set the rotational up vector."
-      value={upVector}
+      label="Orientation"
+      description="Set the orientation or rotation of the model(s) in space."
+      value={orientation}
       onChange={handleChange}
       options={[
         { value: 'y-positive', label: 'Default (Y+ Up)' },
         { value: 'y-negative', label: 'Upside Down (Y- Up)' },
-        { value: 'z-positive', label: 'Flipped 90° (Z+ Up)' },
-        { value: 'z-negative', label: 'Flipped 270° (Z- Up)' },
+        { value: 'z-negative', label: 'Forward 90° (Z- Up)' },
+        { value: 'z-positive', label: 'Back 90° (Z+ Up)' },
       ]}
     />
   );

--- a/src/components/screen-measurement-tools.tsx
+++ b/src/components/screen-measurement-tools.tsx
@@ -90,8 +90,7 @@ export function ScreenMeasurementTools() {
           y2={nextPosition[1]}
         >
           <div>
-            {worldDistance}
-            {measurementUnits}
+            {worldDistance == 0 ? '<0.001' : worldDistance} {measurementUnits}
           </div>
         </foreignObject>
       </>
@@ -184,7 +183,7 @@ export function ScreenMeasurementTools() {
 
       if (labels[i].firstElementChild) {
         labels[i].firstElementChild!.textContent = `
-          ${worldDistance}
+          ${worldDistance == 0 ? '<0.001' : worldDistance}
           ${measurementUnits}
         `;
       }
@@ -198,8 +197,8 @@ export function ScreenMeasurementTools() {
     let worldDistance = distance / camera.zoom;
     if (measurementUnits === 'mm') worldDistance *= 1000;
 
-    // round to two decimal places
-    worldDistance = parseFloat(worldDistance.toFixed(2));
+    // round to three decimal places
+    worldDistance = parseFloat(worldDistance.toFixed(3));
 
     return worldDistance;
   }

--- a/src/components/tab.tsx
+++ b/src/components/tab.tsx
@@ -1,4 +1,4 @@
-import { CameraPanel } from "./camera-panel";
+import { DisplayControls } from "./display-controls";
 import { TabSection } from "./tab-section";
 
 export function Tab({ children }: { children: React.ReactNode }) {
@@ -8,7 +8,7 @@ export function Tab({ children }: { children: React.ReactNode }) {
         <TabSection className='grow'>
           {children}
         </TabSection>
-        <CameraPanel />
+        <DisplayControls />
       </div>
     </div>
   );

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -57,6 +57,7 @@ function Scene({ onLoad, src }: ViewerProps) {
     gridEnabled,
     loading,
     mode,
+    orientation,
     orthographicEnabled,
     setAnnotations,
     setLoading,
@@ -74,6 +75,11 @@ function Scene({ onLoad, src }: ViewerProps) {
     setSrcs(srcs);
     setAnnotations([]);
   }, [src]);
+
+  // orientation changed
+  useEffect(() => {
+    recenter();
+  }, [orientation]);
 
   // upVector changed
   useEffect(() => {
@@ -296,7 +302,7 @@ function Scene({ onLoad, src }: ViewerProps) {
       <Bounds lineVisible={boundsEnabled && mode == 'scene'}>
         <Suspense fallback={<Loader />}>
           {srcs.map((src, index) => {
-            return <GLTF key={index} {...src} />;
+            return <GLTF key={index} {...src} orientation={orientation} />;
           })}
         </Suspense>
       </Bounds>

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -45,7 +45,7 @@ function Scene({ onLoad, src }: ViewerProps) {
 
   const cameraPosition = new Vector3();
   const cameraTarget = new Vector3();
-  const environment = 'apartment';
+  const environment = 'warehouse';
   const { camera, gl } = useThree();
 
   let boundingSphereRadius: number | null = null;

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -184,18 +184,7 @@ function Scene({ onLoad, src }: ViewerProps) {
   function getAxesProperties(): [size?: number | undefined] {
     if (boundsRef.current) {
       if (!boundingSphereRadius) boundingSphereRadius = getBoundingSphereRadius(boundsRef.current);
-
-      const breakPoints = [0.001, 0.01, 0.1, 1.0, 10.0, 100.0];
-      let axisLength = 100.0; // maximum possible value, reduce to scale with object
-
-      for (const breakPoint of breakPoints) {
-        if (boundingSphereRadius! < breakPoint) {
-          axisLength = breakPoint;
-          break;
-        } 
-      }
-
-      return [axisLength];
+      return [boundingSphereRadius * 2];
     } else {
       return [5];
     }

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -181,12 +181,32 @@ function Scene({ onLoad, src }: ViewerProps) {
     return cameraUpChange;
   }
 
+  function getAxesProperties(): [size?: number | undefined] {
+    if (boundsRef.current) {
+      if (!boundingSphereRadius) boundingSphereRadius = getBoundingSphereRadius(boundsRef.current);
+
+      const breakPoints = [0.001, 0.01, 0.1, 1.0, 10.0, 100.0];
+      let axisLength = 100.0; // maximum possible value, reduce to scale with object
+
+      for (const breakPoint of breakPoints) {
+        if (boundingSphereRadius! < breakPoint) {
+          axisLength = breakPoint;
+          break;
+        } 
+      }
+
+      return [axisLength];
+    } else {
+      return [5];
+    }
+  }
+
   function getGridProperties(): [size?: number | undefined, divisions?: number | undefined] {
     if (boundsRef.current) {
       if (!boundingSphereRadius) boundingSphereRadius = getBoundingSphereRadius(boundsRef.current);
 
       const breakPoints = [0.001, 0.01, 0.1, 1.0, 10.0, 100.0];
-      let cellWidth = 100.0; // maximum possible value, reduce to scale with object
+      let cellWidth = 10.0; // maximum possible value, reduce to scale with object
 
       for (const breakPoint of breakPoints) {
         if (boundingSphereRadius! < breakPoint) {
@@ -309,7 +329,7 @@ function Scene({ onLoad, src }: ViewerProps) {
       <Environment preset={environment} />
       {Tools[mode]}
       { (gridEnabled && mode == 'scene') && <gridHelper args={getGridProperties()} />}
-      { (axesEnabled && mode == 'scene') && <axesHelper args={[5]} />}
+      { (axesEnabled && mode == 'scene') && <axesHelper args={getAxesProperties()} />}
     </>
   );
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { Src, SrcObj } from '@/types';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { Vector3 } from 'three';
+import { Box3, Object3D, Sphere, Vector3 } from 'three';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -9,6 +9,12 @@ export function cn(...inputs: ClassValue[]) {
 
 export function areObjectsIdentical(a: any, b: any) {
   return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function getBoundingSphereRadius(object: Object3D) {
+  const box = new Box3().setFromObject(object);
+  const sphere = box.getBoundingSphere(new Sphere());
+  return sphere.radius;
 }
 
 export function normalizeSrc(src: Src): SrcObj[] {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { Src, SrcObj, UpVector } from '@/types';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import { Box3, Object3D, Sphere, Vector3 } from 'three';
+import { Box3, Euler, Object3D, Sphere, Vector3 } from 'three';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -106,4 +106,8 @@ export function getEulerAnglesFromOrientation(orientation: UpVector): [number, n
     'z-negative': [Math.PI/2, 0, 0] // rotate 270 degrees around X ccw, points "forward"
   };
   return orientationToEulerAngles[orientation] as [number, number, number];
+}
+
+export function getEulerFromOrientation(orientation: UpVector): Euler {
+  return new Euler().fromArray(getEulerAnglesFromOrientation(orientation || 'y-positive'));
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { Src, SrcObj } from '@/types';
+import { Src, SrcObj, UpVector } from '@/types';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { Box3, Object3D, Sphere, Vector3 } from 'three';
@@ -96,4 +96,14 @@ export function getElementTranslate(el: HTMLElement): number[] | null {
 
 export function setElementTranslate(el: HTMLElement, x: number, y: number) {
   el?.setAttribute('transform', `translate(${x}, ${y})`);
+}
+
+export function getEulerAnglesFromOrientation(orientation: UpVector): [number, number, number] {
+  const orientationToEulerAngles = {
+    'y-positive': [0, 0, 0], // default rotation, points "up"
+    'y-negative': [0, 0, Math.PI], // rotate 180 degrees around Z ccw, points "down"
+    'z-positive': [-Math.PI/2, 0, 0], // rotate 90 degrees around X ccw, points "back"
+    'z-negative': [Math.PI/2, 0, 0] // rotate 270 degrees around X ccw, points "forward"
+  };
+  return orientationToEulerAngles[orientation] as [number, number, number];
 }

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -1,4 +1,4 @@
-import { Vector3 } from 'three';
+import { Euler, Vector3 } from 'three';
 
 export type Annotation = {
   cameraPosition?: Vector3;
@@ -7,4 +7,5 @@ export type Annotation = {
   label?: string;
   normal?: Vector3;
   position?: Vector3;
+  rotation?: Euler;
 };

--- a/src/types/Annotation.ts
+++ b/src/types/Annotation.ts
@@ -1,11 +1,9 @@
-import { Euler, Vector3 } from 'three';
+import { Vector3 } from 'three';
+import { Point } from './Point';
 
-export type Annotation = {
+export type Annotation = Point & {
   cameraPosition?: Vector3;
   cameraTarget?: Vector3;
   description?: string;
   label?: string;
-  normal?: Vector3;
-  position?: Vector3;
-  rotation?: Euler;
 };

--- a/src/types/ObjectMeasurement.ts
+++ b/src/types/ObjectMeasurement.ts
@@ -1,6 +1,3 @@
-import { Vector3 } from 'three';
+import { Point } from './Point';
 
-export type ObjectMeasurement = {
-  normal: Vector3;
-  position: Vector3;
-};
+export type ObjectMeasurement = Point;

--- a/src/types/Point.ts
+++ b/src/types/Point.ts
@@ -1,0 +1,7 @@
+import { Euler, Vector3 } from "three";
+
+export type Point = {
+  normal?: Vector3;
+  position?: Vector3;
+  rotation?: Euler;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './Events';
 export * from './MeasurementMode';
 export * from './Mode';
 export * from './ObjectMeasurement';
+export * from './Point';
 export * from './ScreenMeasurement';
 export * from './Src';
 export * from './UpVector';


### PR DESCRIPTION
This PR is built on top of https://github.com/aleph-viewer/aleph-r3f/pull/9 and probably shouldn't be reviewed until that one is merged. 

This PR: 
* Changes the lighting preset from "apartment" to "warehouse." For MorphoSource purposes, the less dynamic and more flat light benefits 3D objects where the viewer doesn't have strong control over what the initial model rotation is - i.e., the model may come in facing backwards, upside down, etc. Flatter warehouse light also mimics the light one might see in behind-the-scenes in a museum collection space. :)
* In line with the issue mentioned above about not being able to ensure what orientation models come into the viewer with, this PR adds a model orientation/rotation drop-down selector. This selector rotates the model in the scene between "default," "upside-down," "90 degree forward," and "90 degree back" rotations, which hopefully covers most of the orientations that models might have from common 3D editing software.
* Camera Up vector has been removed from the UI (since the model orientation selector largely replaces it), but all the logic is left in case this is needed again.
* When model orientation is changed, annotation position is updated to match. Annotations now store a Euler `rotation` property to record the rotation applied to them, and this rotation is reported in CSV/JSON/text exports of annotations.
* The green/red/blue axes now scale in size to model size, axis length is twice bounding sphere radius distance.
* Camera near and far calculation is improved. Also, guardrails for camera min/max distance (for perspective) and zoom (for orthographic) are now calculated and used. This keeps users from zooming all the way into a model or zooming all the way out from the model until nothing more is present in the viewer viewport.
* Object measurements also update with model rotation setting.