### PR TITLE
Move bunny and other changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,10 @@
     "tailwindcss-animate": "^1.0.6",
     "three": "0.153.0",
     "zustand": "^4.4.7"
+  },
+  "resolutions": {
+    "@types/react": "^18.2.45",
+    "@types/react-csv": "^1.1.10",
+    "@types/react-dom": "^18.2.17"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,8 +24,6 @@ function App() {
           'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/FlightHelmet/glTF/FlightHelmet.gltf',
         'Roberto Clemente Batting Helmet':
           'https://cdn.glitch.global/2658666b-2aa1-4395-8dfe-44a4aaaa0b16/nmah-1981_0706_06-clemente_helmet-100k-2048_std_draco.glb?v=1729600102458',
-        'Stanford Bunny': 
-          'https://raw.githubusercontent.com/JulieWinchester/aleph-assets/main/bunny.glb',
         Shoe: {
           url: 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb',
           requiredStatement:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,13 @@ import { Toaster } from '@/components/ui/sonner';
 import { toast } from 'sonner';
 // @ts-ignore
 import DOMPurify from 'dompurify';
+import useStore from './Store';
 
 function App() {
   const viewerRef = useRef<ViewerRef>(null);
   const loadedUrlsRef = useRef<string[]>([]);
+
+  const { cameraMode } = useStore();
 
   // https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/Models-showcase.md
   // https://github.com/google/model-viewer/tree/master/packages/modelviewer.dev/assets
@@ -76,16 +79,16 @@ function App() {
     // }),
   }));
 
-  // src changed
+  // src or camera mode changed
   useEffect(() => {
     const normalizedSrc = normalizeSrc(src);
     // if the src is already loaded, recenter the camera
     if (normalizedSrc.every((src) => loadedUrlsRef.current.includes(src.url))) {
       setTimeout(() => {
-        viewerRef.current?.recenter();
+        viewerRef.current?.recenterInstant();
       }, 100);
     }
-  }, [src]);
+  }, [src, cameraMode]);
 
   return (
     <div id="container">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,8 @@ function App() {
             scale: [1, 1, 1],
           },
         ] as SrcObj[],
+        'Stanford Bunny': 
+          'https://raw.githubusercontent.com/JulieWinchester/aleph-assets/main/bunny.glb',
         // 'Frog (Draco) URL': 'https://aleph-gltf-models.netlify.app/Frog.glb',
       },
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,7 +87,7 @@ function App() {
     // if the src is already loaded, recenter the camera
     if (normalizedSrc.every((src) => loadedUrlsRef.current.includes(src.url))) {
       setTimeout(() => {
-        viewerRef.current?.recenterInstant();
+        viewerRef.current?.recenter(true);
       }, 100);
     }
   }, [src, cameraMode]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,7 @@ function App() {
       <div id="viewer">
         <Viewer
           ref={viewerRef}
+          envPreset='apartment'
           src={src}
           onLoad={(srcs: SrcObj[]) => {
             console.log(`model${srcs.length > 1 ? 's' : ''} loaded`, srcs);

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -48,7 +48,7 @@ function Scene({ envPreset, onLoad, src }: ViewerProps) {
   const { camera, gl } = useThree();
 
   let boundingSphereRadius: number | null = null;
-  
+
   const {
     ambientLightIntensity,
     axesEnabled,
@@ -319,9 +319,9 @@ function Scene({ envPreset, onLoad, src }: ViewerProps) {
       <ambientLight intensity={ambientLightIntensity} />
       <Bounds lineVisible={boundsEnabled && mode == 'scene'}>
         <Suspense fallback={<Loader />}>
-            {srcs.map((src, index) => {
+          {srcs.map((src, index) => {
             return <GLTF key={index} {...src} orientation={orientation} />;
-            })}
+          })}
         </Suspense>
       </Bounds>
       <Environment preset={envPreset} />

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -310,7 +310,7 @@ function Scene({ onLoad, src }: ViewerProps) {
 
   return (
     <>
-      {orthographicEnabled ? <OrthographicCamera makeDefault position={[0, 0, 2]} /> : <PerspectiveCamera makeDefault position={[0, 0, 2]} />}
+      {orthographicEnabled ? <OrthographicCamera makeDefault position={[0, 0, 2]} /> : <PerspectiveCamera makeDefault fov={30} position={[0, 0, 2]} />}
       <CameraControls ref={cameraRefs.controls} onChange={onCameraChange} />
       <ambientLight intensity={ambientLightIntensity} />
       <Bounds lineVisible={boundsEnabled && mode == 'scene'}>

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -33,7 +33,7 @@ import { AnnotationTools } from './annotation-tools';
 import MeasurementTools from './measurement-tools';
 import { getBoundingSphereRadius, normalizeSrc } from '@/lib/utils';
 
-function Scene({ onLoad, src }: ViewerProps) {
+function Scene({ envPreset, onLoad, src }: ViewerProps) {
   const boundsRef = useRef<Group | null>(null);
   const boundsLineRef = useRef<Group | null>(null);
 
@@ -45,7 +45,6 @@ function Scene({ onLoad, src }: ViewerProps) {
 
   const cameraPosition = new Vector3();
   const cameraTarget = new Vector3();
-  const environment = 'warehouse';
   const { camera, gl } = useThree();
 
   let boundingSphereRadius: number | null = null;
@@ -320,7 +319,7 @@ function Scene({ onLoad, src }: ViewerProps) {
           })}
         </Suspense>
       </Bounds>
-      <Environment preset={environment} />
+      <Environment preset={envPreset} />
       {Tools[mode]}
       { (gridEnabled && mode == 'scene') && <gridHelper args={getGridProperties()} />}
       { (axesEnabled && mode == 'scene') && <axesHelper args={getAxesProperties()} />}

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -24,7 +24,6 @@ import {
   DRAGGING_MEASUREMENT,
   DROPPED_MEASUREMENT,
   RECENTER,
-  RECENTER_INSTANT,
   CAMERA_CONTROLS_ENABLED,
 } from '@/types';
 import useDoubleClick from '@/lib/hooks/use-double-click';
@@ -49,7 +48,7 @@ function Scene({ envPreset, onLoad, src }: ViewerProps) {
   const { camera, gl } = useThree();
 
   let boundingSphereRadius: number | null = null;
-
+  
   const {
     ambientLightIntensity,
     axesEnabled,
@@ -79,7 +78,7 @@ function Scene({ envPreset, onLoad, src }: ViewerProps) {
 
   // orientation changed
   useEffect(() => {
-    recenter();
+    recenter(true);
   }, [orientation]);
 
   // upVector changed
@@ -99,17 +98,11 @@ function Scene({ envPreset, onLoad, src }: ViewerProps) {
     [loading, cameraMode]
   );
 
-  const handleRecenterEvent = () => {
-    recenter();
+  const handleRecenterEvent = (e: any) => {
+    recenter(e.detail);
   };
 
   useEventListener(RECENTER, handleRecenterEvent);
-
-  const handleRecenterInstantEvent = () => {
-    recenter(true);
-  };
-
-  useEventListener(RECENTER_INSTANT, handleRecenterInstantEvent);
 
   const handleCameraEnabledEvent = (e: any) => {
     (cameraRefs.controls.current as any).enabled = e.detail;
@@ -326,9 +319,9 @@ function Scene({ envPreset, onLoad, src }: ViewerProps) {
       <ambientLight intensity={ambientLightIntensity} />
       <Bounds lineVisible={boundsEnabled && mode == 'scene'}>
         <Suspense fallback={<Loader />}>
-          {srcs.map((src, index) => {
+            {srcs.map((src, index) => {
             return <GLTF key={index} {...src} orientation={orientation} />;
-          })}
+            })}
         </Suspense>
       </Bounds>
       <Environment preset={envPreset} />
@@ -344,14 +337,10 @@ const Viewer = (props: ViewerProps, ref: ((instance: unknown) => void) | RefObje
 
   const triggerDoubleClickEvent = useEventTrigger(DBL_CLICK);
   const triggerRecenterEvent = useEventTrigger(RECENTER);
-  const triggerRecenterInstantEvent = useEventTrigger(RECENTER_INSTANT);
 
   useImperativeHandle(ref, () => ({
-    recenter: () => {
-      triggerRecenterEvent();
-    },
-    recenterInstant: () => {
-      triggerRecenterInstantEvent();
+    recenter: (instant?: boolean) => {
+      triggerRecenterEvent(instant);
     },
   }));
 

--- a/src/components/viewer.tsx
+++ b/src/components/viewer.tsx
@@ -157,9 +157,10 @@ function Scene({ envPreset, onLoad, src }: ViewerProps) {
             const width = camera.right - camera.left;
             const height = camera.top - camera.bottom;
             const diameter = boundingSphereRadius * 2;
-
             const zoom = Math.min( width / diameter, height / diameter );
-            cameraRefs.controls.current.maxZoom = zoom * 4;
+
+            // Don't set maximum zoom for multiple objects
+            cameraRefs.controls.current.maxZoom = (srcs.length === 1) ? (zoom*4) : Infinity;
             cameraRefs.controls.current.minZoom = zoom/4;
           }
         }
@@ -169,7 +170,8 @@ function Scene({ envPreset, onLoad, src }: ViewerProps) {
         camera.updateProjectionMatrix();
 
         if (cameraRefs.controls.current) {
-          cameraRefs.controls.current.minDistance = boundingSphereRadius;
+          // Don't set minimum distance for multiple objects
+          cameraRefs.controls.current.minDistance = (srcs.length === 1) ? boundingSphereRadius : Number.EPSILON;
           cameraRefs.controls.current.maxDistance = boundingSphereRadius * 5;
         }
       }

--- a/src/types/Events.ts
+++ b/src/types/Events.ts
@@ -6,7 +6,6 @@ export const DBL_CLICK = 'aldblclick';
 export const DRAGGING_MEASUREMENT = 'aldraggingmeasurement';
 export const DROPPED_MEASUREMENT = 'aldraggedmeasurement';
 export const RECENTER = 'alrecenter';
-export const RECENTER_INSTANT = 'alrecenterinstant';
 
 export type Event =
   | typeof ANNO_CLICK
@@ -16,5 +15,4 @@ export type Event =
   | typeof DBL_CLICK
   | typeof DRAGGING_MEASUREMENT
   | typeof DROPPED_MEASUREMENT
-  | typeof RECENTER
-  | typeof RECENTER_INSTANT;
+  | typeof RECENTER;

--- a/src/types/Events.ts
+++ b/src/types/Events.ts
@@ -6,6 +6,7 @@ export const DBL_CLICK = 'aldblclick';
 export const DRAGGING_MEASUREMENT = 'aldraggingmeasurement';
 export const DROPPED_MEASUREMENT = 'aldraggedmeasurement';
 export const RECENTER = 'alrecenter';
+export const RECENTER_INSTANT = 'alrecenterinstant';
 
 export type Event =
   | typeof ANNO_CLICK
@@ -15,4 +16,5 @@ export type Event =
   | typeof DBL_CLICK
   | typeof DRAGGING_MEASUREMENT
   | typeof DROPPED_MEASUREMENT
-  | typeof RECENTER;
+  | typeof RECENTER
+  | typeof RECENTER_INSTANT;

--- a/src/types/ViewerProps.ts
+++ b/src/types/ViewerProps.ts
@@ -9,4 +9,5 @@ export type ViewerProps = {
 
 export type ViewerRef = {
   recenter: () => void;
+  recenterInstant: () => void;
 };

--- a/src/types/ViewerProps.ts
+++ b/src/types/ViewerProps.ts
@@ -8,6 +8,5 @@ export type ViewerProps = {
 };
 
 export type ViewerRef = {
-  recenter: () => void;
-  recenterInstant: () => void;
+  recenter: (instant?: boolean) => void;
 };

--- a/src/types/ViewerProps.ts
+++ b/src/types/ViewerProps.ts
@@ -1,6 +1,8 @@
+import { PresetsType } from '@react-three/drei/helpers/environment-assets';
 import { SrcObj } from './index';
 
 export type ViewerProps = {
+  envPreset: PresetsType;
   onLoad?: (src: SrcObj[]) => void;
   src: string | SrcObj | SrcObj[];
 };


### PR DESCRIPTION
This PR:
* Moves Stanford Bunny to bottom of asset list
* Sets apartment as default environment preset
* Environment preset can now be set as a property on Viewer and so is configurable
* Perspective Camera FOV has been fixed and is again 30
* Improves look and feel of switching between objects, fixes previous issues, and recentering when switching between objects and camera modes is now instant
* When using multiple objects, maximum zoom (for othographic cameras) and minimum distance (for perspective cameras) are no longer set, allowing for deeper zoom/dolly of multiple object scenes